### PR TITLE
Edit balance by id bug fix: Amount Calculation

### DIFF
--- a/src/controllers/balance.controller.js
+++ b/src/controllers/balance.controller.js
@@ -25,7 +25,7 @@ const getBalance = catchAsync(async (req, res) => {
 });
 
 const updateBalance = catchAsync(async (req, res) => {
-  const balance = await balanceService.createAndEditBalance(req.body);
+  const balance = await balanceService.updateBalanceById(req.body);
   res.send(balance);
 });
 

--- a/src/services/balance.service.js
+++ b/src/services/balance.service.js
@@ -53,15 +53,14 @@ const getBalanceById = async (id) => Balance.findById(id);
  * @param {Object} updateBody
  * @returns {Promise<balance>}
  */
-const updateBalanceById = async (balanceId, updateBody) => {
-  const balance = await getBalanceById(balanceId);
-  if (!balance) {
-    throw new ApiError(httpStatus.NOT_FOUND, 'Balance not found');
-  }
+const updateBalanceById = async (balanceBody) => {
+  const { userId, vendorId } = balanceBody;
+  const query = {
+    userId,
+    vendorId,
+  };
 
-  Object.assign(balance, updateBody);
-  await balance.save();
-  return balance;
+  return Balance.findOneAndUpdate(query, balanceBody, { upsert: true });
 };
 
 /**


### PR DESCRIPTION
## GOAL

Fixed bug of wrong calculation on edit balance

## WORK

On checking out, the amount on backend gets minus from the balance. On the other hand, edit balance was using same API which causing the amount if entered

1000 and balance was 800, so in backend 

finalBalance = balance - 1000 = 800 - 1000 = -200

The goal of edit balance is to directly edit the balance, if I entered 1000, the final balance should set to 1000. But, on order if I did 400 order, it should be

finalBalance = balance - order = 800 - 400 = 400